### PR TITLE
Improve test coverage for varchar macros

### DIFF
--- a/vsuite/test-v.c
+++ b/vsuite/test-v.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <string.h>
+#include <ctype.h>
 #include "v.h"
 
 static int failures = 0;
@@ -90,6 +91,34 @@ static void test_trim_all_spaces(void) {
     CHECK("v_trim all", v.len == 0);
 }
 
+static void test_trim_empty(void) {
+    DECL_VARCHAR(v, 5);
+    v.len = 0;
+    v_ltrim(v);
+    CHECK("v_ltrim empty", v.len == 0);
+    v_rtrim(v);
+    CHECK("v_rtrim empty", v.len == 0);
+    v_trim(v);
+    CHECK("v_trim empty", v.len == 0);
+}
+
+static void test_case_empty(void) {
+    DECL_VARCHAR(v, 3);
+    v.len = 0;
+    v_upper(v);
+    CHECK("v_upper empty", v.len == 0);
+    v_lower(v);
+    CHECK("v_lower empty", v.len == 0);
+}
+
+static void test_copy_self(void) {
+    DECL_VARCHAR(v, 5);
+    strcpy(v.arr, "abc");
+    v.len = 3;
+    int n = v_copy(v, v);
+    CHECK("v_copy self", n == 3 && v.len == 3 && memcmp(v.arr, "abc", 3) == 0);
+}
+
 static void test_large_copy(void) {
     enum { N = 4096 };
     DECL_VARCHAR(src, N); DECL_VARCHAR(dst, N);
@@ -117,7 +146,10 @@ int main(int argc, char **argv) {
     test_trim();
     test_trim_noop();
     test_trim_all_spaces();
+    test_trim_empty();
     test_large_copy();
+    test_case_empty();
+    test_copy_self();
     test_case();
     if (failures == 0) {
         printf(verbose ? "\nAll tests passed.\n" : "\n");

--- a/vsuite/test-zv.c
+++ b/vsuite/test-zv.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "zv.h"
+#include <ctype.h>
 
 static int failures = 0;
 static int verbose = 0;
@@ -97,6 +98,44 @@ static void test_zero_term_empty(void) {
     CHECK("zv_zero_term empty", v.len == 0 && v.arr[0] == '\0');
 }
 
+static void test_trim_empty(void) {
+    DECL_VARCHAR(v,5);
+    v.arr[0] = '\0';
+    v.len = 0;
+    zv_ltrim(v);
+    CHECK("zv_ltrim empty", v.len == 0 && v.arr[0] == '\0');
+    zv_rtrim(v);
+    CHECK("zv_rtrim empty", v.len == 0 && v.arr[0] == '\0');
+    zv_trim(v);
+    CHECK("zv_trim empty", v.len == 0 && v.arr[0] == '\0');
+}
+
+static void test_case_empty(void) {
+    DECL_VARCHAR(v,1);
+    v.arr[0] = '\0';
+    v.len = 0;
+    zv_upper(v);
+    CHECK("zv_upper empty", v.len == 0 && v.arr[0] == '\0');
+    zv_lower(v);
+    CHECK("zv_lower empty", v.len == 0 && v.arr[0] == '\0');
+}
+
+static void test_copy_self(void) {
+    DECL_VARCHAR(v,5);
+    strcpy(v.arr, "abc");
+    v.len = 3;
+    int n = zv_copy(v, v);
+    CHECK("zv_copy self", n == 3 && v.len == 3 && strcmp(v.arr, "abc") == 0);
+}
+
+static void test_zero_term_idempotent(void) {
+    DECL_VARCHAR(v,4);
+    strcpy(v.arr, "abc");
+    v.len = 3;
+    zv_zero_term(v);
+    CHECK("zv_zero_term idempotent", v.len == 3 && strcmp(v.arr, "abc") == 0);
+}
+
 static void test_large_copy(void) {
     enum { N = 4096 };
     DECL_VARCHAR(src, N); DECL_VARCHAR(dst, N);
@@ -124,7 +163,11 @@ int main(int argc, char **argv) {
     test_trim();
     test_trim_noop();
     test_trim_all_spaces();
+    test_trim_empty();
     test_zero_term_empty();
+    test_zero_term_idempotent();
+    test_case_empty();
+    test_copy_self();
     test_large_copy();
     test_case();
     if (failures == 0) {


### PR DESCRIPTION
## Summary
- expand test coverage for fixed `VARCHAR` macros
- add additional tests for zero-terminated variants

## Testing
- `make -C vsuite`
- `./vsuite/test-v.exe`
- `./vsuite/test-zv.exe`
- `make -C ref/varchar-check`
- `./ref/varchar-check/test-suite.exe`


------
https://chatgpt.com/codex/tasks/task_b_687d299f24408326ac68ddfa3fc58d8b