### PR TITLE
Add comprehensive tests for string macros

### DIFF
--- a/include/vsuite/vd.h
+++ b/include/vsuite/vd.h
@@ -22,7 +22,8 @@
 #define vd_dup(v) vd_dup_fcn(V_BUF(v), (v).len)
 
 /* Duplicate Fixed VARCHAR into newly allocated Dynamic C String */
-static inline char *vd_dup_fcn(const varchar_buf_t *src_buf, unsigned short src_len)
+static inline char *vd_dup_fcn(const char *src_buf, unsigned short src_len)
+{
     char *d = malloc(src_len + 1);
     if (!d) return NULL;
     memcpy(d, src_buf, src_len);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,10 @@
-PROGRAMS = test-v.exe test-zv.exe
+PROGRAMS = test-v.exe test-zv.exe test-vf.exe test-fv.exe test-vd.exe test-dv.exe
 
 INC=../include
 
 IV=${INC}/vsuite
 
-CFLAGS = -Wall -Wextra -std=c99 -I${INC}
+CFLAGS = -Wall -Wextra -std=gnu99 -I${INC}
 
 .PHONY: all test clean
 
@@ -17,15 +17,19 @@ test-v.exe:    test-v.c    ${IV}/v.h
 
 test-zv.exe:   test-zv.c   ${IV}/v.h  ${IV}/zv.h
 
-# test-vf.exe:   test-vf.c   ${IV}/v.h  ${IV}/vf.h
-# test-fv.exe:   test-vf.c   ${IV}/v.h  ${IV}/fv.h
-# test-vd.exe:   test-vd.c   ${IV}/v.h  ${IV}/vd.h
-# test-dv.exe:   test-dv.c   ${IV}/v.h  ${IV}/dv.h
+test-vf.exe:   test-vf.c   ${IV}/v.h  ${IV}/vf.h
+test-fv.exe:   test-fv.c   ${IV}/v.h  ${IV}/fv.h
+test-vd.exe:   test-vd.c   ${IV}/v.h  ${IV}/vd.h
+test-dv.exe:   test-dv.c   ${IV}/v.h  ${IV}/dv.h
 
 test: all
 	mkdir -p log
 	./test-v.exe   2>&1  | tee log/test-v.txt
 	./test-zv.exe  2>&1  | tee log/test-zv.txt
+	./test-vf.exe  2>&1  | tee log/test-vf.txt
+	./test-fv.exe  2>&1  | tee log/test-fv.txt
+	./test-vd.exe  2>&1  | tee log/test-vd.txt
+	./test-dv.exe  2>&1  | tee log/test-dv.txt
 
 clean:
 	rm -f $(PROGRAMS) *.o

--- a/tests/test-dv.c
+++ b/tests/test-dv.c
@@ -1,0 +1,49 @@
+#include <stdio.h>
+#include <string.h>
+#include "vsuite/v.h"
+#include "vsuite/dv.h"
+
+static int failures = 0;
+static int verbose = 0;
+
+#define CHECK(name, expr) do { \
+    if (!(expr)) { \
+        printf("\nFAIL: %s\n", name); \
+        failures++; \
+    } else if (verbose) { \
+        printf("PASS: %s\n", name); \
+    } else { \
+        fputc('.', stdout); fflush(stdout); \
+    } \
+} while (0)
+
+static void test_copy(void) {
+    VARCHAR(dst, 6);
+    const char *src = "abc";
+    dv_copy(dst, src);
+    CHECK("dv_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
+}
+
+static void test_copy_overflow(void) {
+    VARCHAR(dst, 4);
+    const char *src = "abcd";
+    dv_copy(dst, src);
+    CHECK("dv_copy overflow", dst.len == 0);
+}
+
+static void test_copy_empty(void) {
+    VARCHAR(dst, 4);
+    const char *src = "";
+    dv_copy(dst, src);
+    CHECK("dv_copy empty", dst.len == 0);
+}
+
+int main(int argc, char **argv) {
+    for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v")) verbose = 1;
+    test_copy();
+    test_copy_overflow();
+    test_copy_empty();
+    if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
+    else printf("\n%d test(s) failed.\n", failures);
+    return failures;
+}

--- a/tests/test-fv.c
+++ b/tests/test-fv.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <string.h>
+#include "vsuite/v.h"
+#include "vsuite/fv.h"
+
+static int failures = 0;
+static int verbose = 0;
+
+#define CHECK(name, expr) do { \
+    if (!(expr)) { \
+        printf("\nFAIL: %s\n", name); \
+        failures++; \
+    } else if (verbose) { \
+        printf("PASS: %s\n", name); \
+    } else { \
+        fputc('.', stdout); fflush(stdout); \
+    } \
+} while (0)
+
+static void test_copy(void) {
+    char dst[6];
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abc"); src.len = 3;
+    fv_copy(dst, src);
+    CHECK("fv_copy len", strcmp(dst, "abc") == 0);
+}
+
+static void test_copy_overflow(void) {
+    char dst[4];
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abcd"); src.len = 4;
+    fv_copy(dst, src);
+    CHECK("fv_copy overflow", dst[0] == '\0');
+}
+
+static void test_copy_empty(void) {
+    char dst[4];
+    VARCHAR(src, 4);
+    src.len = 0; src.arr[0] = '\0';
+    fv_copy(dst, src);
+    CHECK("fv_copy empty", dst[0] == '\0');
+}
+
+int main(int argc, char **argv) {
+    for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v")) verbose = 1;
+    test_copy();
+    test_copy_overflow();
+    test_copy_empty();
+    if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
+    else printf("\n%d test(s) failed.\n", failures);
+    return failures;
+}

--- a/tests/test-v.c
+++ b/tests/test-v.c
@@ -93,7 +93,7 @@ static void test_trim_all_spaces(void) {
 }
 
 static void test_trim_empty(void) {
-    DECL_VARCHAR(v, 5);
+    VARCHAR(v, 5);
     v.len = 0;
     v_ltrim(v);
     CHECK("v_ltrim empty", v.len == 0);
@@ -104,7 +104,7 @@ static void test_trim_empty(void) {
 }
 
 static void test_case_empty(void) {
-    DECL_VARCHAR(v, 3);
+    VARCHAR(v, 3);
     v.len = 0;
     v_upper(v);
     CHECK("v_upper empty", v.len == 0);
@@ -113,7 +113,7 @@ static void test_case_empty(void) {
 }
 
 static void test_copy_self(void) {
-    DECL_VARCHAR(v, 5);
+    VARCHAR(v, 5);
     strcpy(v.arr, "abc");
     v.len = 3;
     int n = v_copy(v, v);

--- a/tests/test-vd.c
+++ b/tests/test-vd.c
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "vsuite/v.h"
+#include "vsuite/vd.h"
+
+static int failures = 0;
+static int verbose = 0;
+
+#define CHECK(name, expr) do { \
+    if (!(expr)) { \
+        printf("\nFAIL: %s\n", name); \
+        failures++; \
+    } else if (verbose) { \
+        printf("PASS: %s\n", name); \
+    } else { \
+        fputc('.', stdout); fflush(stdout); \
+    } \
+} while (0)
+
+static void test_copy(void) {
+    VARCHAR(src, 6);
+    char dst[6];
+    strcpy(src.arr, "abc"); src.len = 3;
+    vd_copy(dst, sizeof(dst), src);
+    CHECK("vd_copy len", strcmp(dst, "abc") == 0);
+}
+
+static void test_copy_overflow(void) {
+    VARCHAR(src, 6);
+    char dst[4];
+    strcpy(src.arr, "abcd"); src.len = 4;
+    vd_copy(dst, sizeof(dst), src);
+    CHECK("vd_copy overflow", dst[0] == '\0');
+}
+
+static void test_copy_zero_cap(void) {
+    VARCHAR(src, 6);
+    char dst[1];
+    strcpy(src.arr, "a"); src.len = 1;
+    dst[0] = 'x';
+    vd_copy(dst, 0, src);
+    CHECK("vd_copy zero cap", dst[0] == 'x'); /* unchanged */
+}
+
+static void test_dup(void) {
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abc"); src.len = 3;
+    char *d = vd_dup(src);
+    CHECK("vd_dup", d && strcmp(d, "abc") == 0);
+    free(d);
+}
+
+int main(int argc, char **argv) {
+    for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v")) verbose = 1;
+    test_copy();
+    test_copy_overflow();
+    test_copy_zero_cap();
+    test_dup();
+    if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
+    else printf("\n%d test(s) failed.\n", failures);
+    return failures;
+}

--- a/tests/test-vf.c
+++ b/tests/test-vf.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <string.h>
+#include "vsuite/v.h"
+#include "vsuite/vf.h"
+
+static int failures = 0;
+static int verbose = 0;
+
+#define CHECK(name, expr) do { \
+    if (!(expr)) { \
+        printf("\nFAIL: %s\n", name); \
+        failures++; \
+    } else if (verbose) { \
+        printf("PASS: %s\n", name); \
+    } else { \
+        fputc('.', stdout); fflush(stdout); \
+    } \
+} while (0)
+
+static void test_copy(void) {
+    VARCHAR(dst, 6);
+    vf_copy(dst, "abc");
+    CHECK("vf_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
+}
+
+static void test_copy_overflow(void) {
+    VARCHAR(dst, 3);
+    vf_copy(dst, "abcd");
+    CHECK("vf_copy overflow", dst.len == 0);
+}
+
+static void test_copy_empty(void) {
+    VARCHAR(dst, 4);
+    vf_copy(dst, "");
+    CHECK("vf_copy empty", dst.len == 0);
+}
+
+int main(int argc, char **argv) {
+    for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v")) verbose = 1;
+    test_copy();
+    test_copy_overflow();
+    test_copy_empty();
+    if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
+    else printf("\n%d test(s) failed.\n", failures);
+    return failures;
+}

--- a/tests/test-zv.c
+++ b/tests/test-zv.c
@@ -100,7 +100,7 @@ static void test_zero_term_empty(void) {
 }
 
 static void test_trim_empty(void) {
-    DECL_VARCHAR(v,5);
+    VARCHAR(v,5);
     v.arr[0] = '\0';
     v.len = 0;
     zv_ltrim(v);
@@ -112,7 +112,7 @@ static void test_trim_empty(void) {
 }
 
 static void test_case_empty(void) {
-    DECL_VARCHAR(v,1);
+    VARCHAR(v,1);
     v.arr[0] = '\0';
     v.len = 0;
     zv_upper(v);
@@ -122,7 +122,7 @@ static void test_case_empty(void) {
 }
 
 static void test_copy_self(void) {
-    DECL_VARCHAR(v,5);
+    VARCHAR(v,5);
     strcpy(v.arr, "abc");
     v.len = 3;
     int n = zv_copy(v, v);
@@ -130,7 +130,7 @@ static void test_copy_self(void) {
 }
 
 static void test_zero_term_idempotent(void) {
-    DECL_VARCHAR(v,4);
+    VARCHAR(v,4);
     strcpy(v.arr, "abc");
     v.len = 3;
     zv_zero_term(v);


### PR DESCRIPTION
## Summary
- fix missing brace in `vd.h`
- switch tests to gnu99 so typeof works
- replace nonexistent DECL_VARCHAR macro uses
- add tests for fixed/dynamic conversion macros
- enable new tests in Makefile

## Testing
- `make -C tests test`

------
https://chatgpt.com/codex/tasks/task_b_687d2fb82bc8832694bd429b9209810c