### PR TITLE
Fix self-copy warnings by switching memcpy to memmove

### DIFF
--- a/vsuite/v.h
+++ b/vsuite/v.h
@@ -24,7 +24,7 @@
 /* Copy into another fixed VARCHAR; returns number of bytes copied or 0 on failure */
 #define v_copy(dest, src)                                                      \
     ((V_SIZE(dest) >= (src).len)                                               \
-        ? (memcpy(V_BUF(dest), V_BUF(src), (src).len),                         \
+        ? (memmove(V_BUF(dest), V_BUF(src), (src).len),                        \
            (dest).len = (src).len,                                             \
            (src).len)                                                          \
         : ((dest).len = 0, 0))

--- a/vsuite/zv.h
+++ b/vsuite/zv.h
@@ -33,7 +33,7 @@
 /* zv_copy: like v_copy but guarantees \0 termination */
 #define zv_copy(dest, src)                                                      \
     ((V_SIZE(dest) > (src).len)                                                 \
-        ? (memcpy(V_BUF(dest), V_BUF(src), (src).len),                          \
+        ? (memmove(V_BUF(dest), V_BUF(src), (src).len),                          \
            (dest).len = (src).len,                                              \
            V_BUF(dest)[(dest).len] = '\0',                                     \
            (src).len)                                                           \


### PR DESCRIPTION
## Summary
- fix warnings about aliased arguments on v_copy/zv_copy
- run reference tests

## Testing
- `gcc -Wall -Wextra -std=gnu99 -I. -o /tmp/test.exe /tmp/test.c`
- `./ref/varchar-check/test-suite.exe`

------
https://chatgpt.com/codex/tasks/task_b_687d3325d0708326b60796aceecf07ee