### PR TITLE
Fix argument order in copy macros

### DIFF
--- a/include/vsuite/dv.h
+++ b/include/vsuite/dv.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 
 /* Copy from Dynamic C String to Fixed VARCHAR */
-#define dv_copy(vdst, dsrc)                                                   \
+#define vd_copy(vdst, dsrc)                                                   \
     do {                                                                      \
         size_t __n = strlen(dsrc);                                            \
         if (__n < V_SIZE(vdst)) {                                             \

--- a/include/vsuite/vd.h
+++ b/include/vsuite/vd.h
@@ -8,7 +8,7 @@
 #include <vsuite/v.h>
 
 /* Copy from Fixed VARCHAR to Dynamic C String (preallocated dest) */
-#define vd_copy(dstr, dcap, vsrc)                                             \
+#define dv_copy(dstr, dcap, vsrc)                                             \
     do {                                                                      \
         if ((vsrc).len < (dcap)) {                                            \
             memcpy(dstr, V_BUF(vsrc), (vsrc).len);                            \

--- a/tests/test-dv.c
+++ b/tests/test-dv.c
@@ -20,22 +20,22 @@ static int verbose = 0;
 static void test_copy(void) {
     VARCHAR(dst, 6);
     const char *src = "abc";
-    dv_copy(dst, src);
-    CHECK("dv_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
+    vd_copy(dst, src);
+    CHECK("vd_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
 }
 
 static void test_copy_overflow(void) {
     VARCHAR(dst, 4);
     const char *src = "abcd";
-    dv_copy(dst, src);
-    CHECK("dv_copy overflow", dst.len == 0);
+    vd_copy(dst, src);
+    CHECK("vd_copy overflow", dst.len == 0);
 }
 
 static void test_copy_empty(void) {
     VARCHAR(dst, 4);
     const char *src = "";
-    dv_copy(dst, src);
-    CHECK("dv_copy empty", dst.len == 0);
+    vd_copy(dst, src);
+    CHECK("vd_copy empty", dst.len == 0);
 }
 
 int main(int argc, char **argv) {

--- a/tests/test-vd.c
+++ b/tests/test-vd.c
@@ -22,16 +22,16 @@ static void test_copy(void) {
     VARCHAR(src, 6);
     char dst[6];
     strcpy(src.arr, "abc"); src.len = 3;
-    vd_copy(dst, sizeof(dst), src);
-    CHECK("vd_copy len", strcmp(dst, "abc") == 0);
+    dv_copy(dst, sizeof(dst), src);
+    CHECK("dv_copy len", strcmp(dst, "abc") == 0);
 }
 
 static void test_copy_overflow(void) {
     VARCHAR(src, 6);
     char dst[4];
     strcpy(src.arr, "abcd"); src.len = 4;
-    vd_copy(dst, sizeof(dst), src);
-    CHECK("vd_copy overflow", dst[0] == '\0');
+    dv_copy(dst, sizeof(dst), src);
+    CHECK("dv_copy overflow", dst[0] == '\0');
 }
 
 static void test_copy_zero_cap(void) {
@@ -39,8 +39,8 @@ static void test_copy_zero_cap(void) {
     char dst[1];
     strcpy(src.arr, "a"); src.len = 1;
     dst[0] = 'x';
-    vd_copy(dst, 0, src);
-    CHECK("vd_copy zero cap", dst[0] == 'x'); /* unchanged */
+    dv_copy(dst, 0, src);
+    CHECK("dv_copy zero cap", dst[0] == 'x'); /* unchanged */
 }
 
 static void test_dup(void) {


### PR DESCRIPTION
## Summary
- align dv/vd copy macro names with argument order
- adjust related tests

## Testing
- `make -C tests test`

------
https://chatgpt.com/codex/tasks/task_b_687d4a761e788326aa35c4ca3abc2ccd