### PR TITLE
Fix dv/vd prefix mismatch in tests

### DIFF
--- a/include/vsuite/dv.h
+++ b/include/vsuite/dv.h
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 /* Copy from Fixed VARCHAR to Dynamic C String (preallocated dest) */
 #define dv_copy(dstr, dcap, vsrc)                                             \

--- a/tests/test-dv.c
+++ b/tests/test-dv.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "vsuite/v.h"
 #include "vsuite/dv.h"
+#include <stdlib.h>
 
 static int failures = 0;
 static int verbose = 0;
@@ -18,24 +19,44 @@ static int verbose = 0;
 } while (0)
 
 static void test_copy(void) {
-    VARCHAR(dst, 6);
-    const char *src = "abc";
-    vd_copy(dst, src);
-    CHECK("vd_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
+    char dst[6];
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abc"); src.len = 3;
+    dv_copy(dst, sizeof(dst), src);
+    CHECK("dv_copy len", strcmp(dst, "abc") == 0);
 }
 
 static void test_copy_overflow(void) {
-    VARCHAR(dst, 4);
-    const char *src = "abcd";
-    vd_copy(dst, src);
-    CHECK("vd_copy overflow", dst.len == 0);
+    char dst[4];
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abcd"); src.len = 4;
+    dv_copy(dst, sizeof(dst), src);
+    CHECK("dv_copy overflow", dst[0] == '\0');
 }
 
 static void test_copy_empty(void) {
-    VARCHAR(dst, 4);
-    const char *src = "";
-    vd_copy(dst, src);
-    CHECK("vd_copy empty", dst.len == 0);
+    char dst[4];
+    VARCHAR(src, 4);
+    src.len = 0; src.arr[0] = '\0';
+    dv_copy(dst, sizeof(dst), src);
+    CHECK("dv_copy empty", dst[0] == '\0');
+}
+
+static void test_copy_zero_cap(void) {
+    char dst[1];
+    VARCHAR(src, 2);
+    strcpy(src.arr, "a"); src.len = 1;
+    dst[0] = 'x';
+    dv_copy(dst, 0, src);
+    CHECK("dv_copy zero cap", dst[0] == 'x');
+}
+
+static void test_dup(void) {
+    VARCHAR(src, 6);
+    strcpy(src.arr, "abc"); src.len = 3;
+    char *d = dv_dup(src);
+    CHECK("dv_dup", d && strcmp(d, "abc") == 0);
+    free(d);
 }
 
 int main(int argc, char **argv) {
@@ -43,6 +64,8 @@ int main(int argc, char **argv) {
     test_copy();
     test_copy_overflow();
     test_copy_empty();
+    test_copy_zero_cap();
+    test_dup();
     if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
     else printf("\n%d test(s) failed.\n", failures);
     return failures;

--- a/tests/test-vd.c
+++ b/tests/test-vd.c
@@ -19,44 +19,31 @@ static int verbose = 0;
 } while (0)
 
 static void test_copy(void) {
-    VARCHAR(src, 6);
-    char dst[6];
-    strcpy(src.arr, "abc"); src.len = 3;
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy len", strcmp(dst, "abc") == 0);
+    VARCHAR(dst, 6);
+    const char *src = "abc";
+    vd_copy(dst, src);
+    CHECK("vd_copy len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
 }
 
 static void test_copy_overflow(void) {
-    VARCHAR(src, 6);
-    char dst[4];
-    strcpy(src.arr, "abcd"); src.len = 4;
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy overflow", dst[0] == '\0');
+    VARCHAR(dst, 4);
+    const char *src = "abcd";
+    vd_copy(dst, src);
+    CHECK("vd_copy overflow", dst.len == 0);
 }
 
-static void test_copy_zero_cap(void) {
-    VARCHAR(src, 6);
-    char dst[1];
-    strcpy(src.arr, "a"); src.len = 1;
-    dst[0] = 'x';
-    dv_copy(dst, 0, src);
-    CHECK("dv_copy zero cap", dst[0] == 'x'); /* unchanged */
-}
-
-static void test_dup(void) {
-    VARCHAR(src, 6);
-    strcpy(src.arr, "abc"); src.len = 3;
-    char *d = vd_dup(src);
-    CHECK("vd_dup", d && strcmp(d, "abc") == 0);
-    free(d);
+static void test_copy_empty(void) {
+    VARCHAR(dst, 4);
+    const char *src = "";
+    vd_copy(dst, src);
+    CHECK("vd_copy empty", dst.len == 0);
 }
 
 int main(int argc, char **argv) {
     for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v")) verbose = 1;
     test_copy();
     test_copy_overflow();
-    test_copy_zero_cap();
-    test_dup();
+    test_copy_empty();
     if (failures == 0) printf(verbose ? "\nAll tests passed.\n" : "\n");
     else printf("\n%d test(s) failed.\n", failures);
     return failures;


### PR DESCRIPTION
## Summary
- respect dest/src prefix ordering in tests
- include `<stdlib.h>` for `dv_dup`

## Testing
- `make -C tests`
- `cd tests && ./test-v.exe -v && ./test-zv.exe -v && ./test-vf.exe -v && ./test-fv.exe -v && ./test-vd.exe -v && ./test-dv.exe -v && cd ..`

------
https://chatgpt.com/codex/tasks/task_b_687d6ef9addc83269e1020b2b9ee6404