### PR TITLE
Add documentation and tests for helper macros

### DIFF
--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -183,6 +183,14 @@ const char *dyn = getenv("HOME");
 vd_copy(tmp, dyn);
 ```
 
+ - `zvd_copy(vdst, dsrc)` – like `vd_copy` but always NUL terminates the
+   destination even when the source overflows.
+
+```c
+const char *src = "abc";
+zvd_copy(tmp, src);
+```
+
 #### `fixed.h`
 
 - `fv_copy(dst, src)` – copy a fixed `VARCHAR` into a fixed array.
@@ -197,6 +205,14 @@ fv_copy(fixed, tmp);
 ```c
 VARCHAR(v, 8);
 vf_copy(v, "hello");
+```
+
+`zvf_copy(vdst, csrc)` – zero-terminating form of `vf_copy` that
+ensures the destination always contains a NUL terminator.
+
+```c
+VARCHAR(v2, 4);
+zvf_copy(v2, "ab");
 ```
 
 ### Zero-terminated variant (`zvarchar.h`)

--- a/tests/test-cstr.c
+++ b/tests/test-cstr.c
@@ -222,6 +222,22 @@ static void test_dv_dup_large(void) {
     free(d);
 }
 
+/* Directly exercise dv_dup_fcn with a small string. */
+static void test_dv_dup_fcn_basic(void) {
+    const char src[] = "xyz";
+    char *d = dv_dup_fcn(src, 3);
+    CHECK("dv_dup_fcn basic", d && strcmp(d, "xyz") == 0);
+    free(d);
+}
+
+/* dv_dup_fcn should handle empty strings. */
+static void test_dv_dup_fcn_empty(void) {
+    const char src[] = "";
+    char *d = dv_dup_fcn(src, 0);
+    CHECK("dv_dup_fcn empty", d && *d == '\0');
+    free(d);
+}
+
 int main(int argc, char **argv) {
     for (int i=1;i<argc;i++)
         verbose |= (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose"));
@@ -246,6 +262,8 @@ int main(int argc, char **argv) {
     test_dv_dup_basic();
     test_dv_dup_empty();
     test_dv_dup_large();
+    test_dv_dup_fcn_basic();
+    test_dv_dup_fcn_empty();
 
     if (failures == 0)
         printf(verbose ? "\nAll tests passed.\n" : "\n");

--- a/tests/test-varchar.c
+++ b/tests/test-varchar.c
@@ -246,6 +246,22 @@ static void test_mass_case(void) {
         if (v.arr[i] != 'a') { CHECK("v_mass_lower", 0); break; }
 }
 
+/*
+ * Test helper macros V_SIZE(), V_BUF() and varchar_buf_t.  V_SIZE should
+ * report the declared capacity while V_BUF must point at the underlying
+ * array.  The varchar_buf_t typedef resolves to a single character array.
+ */
+static void test_helper_macros(void) {
+    VARCHAR(v, 4);
+    strcpy(v.arr, "abc");
+    v.len = 3;
+    CHECK("V_SIZE", V_SIZE(v) == 4);
+    char *p = V_BUF(v);
+    p[0] = 'x';
+    CHECK("V_BUF", v.arr[0] == 'x');
+    CHECK("varchar_buf_t", sizeof(varchar_buf_t) == 1);
+}
+
 int main(int argc, char **argv) {
     for (int i=1;i<argc;i++) if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) verbose = 1;
 
@@ -271,6 +287,7 @@ int main(int argc, char **argv) {
     test_case_empty();
     test_case();
     test_mass_case();
+    test_helper_macros();
 
     if (failures == 0) {
         printf(verbose ? "\nAll tests passed.\n" : "\n");

--- a/tests/test-zvarchar.c
+++ b/tests/test-zvarchar.c
@@ -86,6 +86,14 @@ static void test_has_capacity(void) {
                                   zv_has_capacity(tiny, 0));
 }
 
+/* ZV_CAPACITY reports the usable size excluding the terminator. */
+static void test_zv_capacity(void) {
+    VARCHAR(v, 5);
+    CHECK("ZV_CAPACITY", ZV_CAPACITY(v) == 4);
+    VARCHAR(tiny, 1);
+    CHECK("ZV_CAPACITY zero", ZV_CAPACITY(tiny) == 0);
+}
+
 /*
  * zv_zero_term() should ensure the string is terminated.  If the length is
  * within bounds it simply writes a terminator, otherwise it truncates the
@@ -327,6 +335,7 @@ int main(int argc, char **argv) {
     test_valid_zero_len_good_term();
     test_valid_zero_len_bad_term();
     test_has_capacity();
+    test_zv_capacity();
 
     test_zero_term();
     test_zero_term_idempotent();


### PR DESCRIPTION
## Summary
- document `zvd_copy` and `zvf_copy` in the Developer Guide
- add tests for helper macros: `V_SIZE`, `V_BUF`, `varchar_buf_t` and `ZV_CAPACITY`
- exercise `dv_dup_fcn` directly in the cstring tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_687ebef55de48326a74f2a5fa314214a