### PR TITLE
Rename cstr API to pstr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ the C standard library. The design notes in `doc/Concept.md` list the prefixes:
 - 'x_'  -- Pointers to VARCHAR
 - 'vf_' -- Fixed VARCHAR  ← fixed C string
 - 'fv_' -- Fixed C string ← fixed VARCHAR
-- 'vd_' -- Fixed VARCHAR  ← dynamic C string
+- 'vp_' -- Fixed VARCHAR  ← C string pointer
+- 'pv_' -- C string pointer ← fixed VARCHAR
 - 'dv_' -- Dynamic string ← fixed VARCHAR
 ```
 
@@ -67,7 +68,7 @@ example, a fixed/dynamic comparison routine might be called `dv_strcmp`.
 
 Simple helper functions that need to appear in headers should be declared
 `static inline`. For instance, `dv_dup_fcn` is defined this way in
-`include/vsuite/cstr.h`:
+`include/vsuite/pstr.h`:
 
 ```c
 static inline char *dv_dup_fcn(const char *src_buf, unsigned short src_len)

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -16,7 +16,7 @@ This guide summarizes the design of VSuite and explains the naming conventions f
     - VARCHAR <-> Fixed:
       - [`fixed.h`](#fixedh)
     - VARCHAR <-> Dynamic:
-      - [`cstr.h`](#cstrh)
+      - [`pstr.h`](#pstrh)
 - [Further Reading](#further-reading)
 
 ## Design Overview
@@ -77,7 +77,7 @@ src.len = 5;
 v_copy(dst, src);           /* copies when dst is large enough */
 ```
 
-Copy into a dynamic string:
+Copy into a C string buffer:
 
 ```c
 char buf[8];
@@ -86,7 +86,7 @@ strcpy(v.arr, "hi");
 v.len = 2;
 
 /* writes NUL on failure */
-dv_copy(buf, sizeof buf, v);
+pv_copy(buf, sizeof buf, v);
 ```
 
 ## Error Handling and Truncation
@@ -159,13 +159,13 @@ v_upper(tmp);                   /* "ABC" */
 
 ### Interop helpers
 
-#### `cstr.h`
+#### `pstr.h`
 
-- `dv_copy(dst, cap, src)` – copy a fixed `VARCHAR` into a dynamic buffer.
+- `pv_copy(dst, cap, src)` – copy a fixed `VARCHAR` into a C string buffer.
 
 ```c
 char out[5];
-dv_copy(out, sizeof out, tmp);
+pv_copy(out, sizeof out, tmp);
 ```
 
 - `dv_dup(src)` – allocate a new C string containing the contents of `src`.
@@ -175,20 +175,20 @@ char *dup = dv_dup(tmp);
 free(dup);
 ```
 
-- `vd_copy(vdst, dsrc)` – copy from a dynamic C string into a fixed
+- `vp_copy(vdst, dsrc)` – copy from a C string pointer into a fixed
   `VARCHAR`.
 
 ```c
 const char *dyn = getenv("HOME");
-vd_copy(tmp, dyn);
+vp_copy(tmp, dyn);
 ```
 
- - `zvd_copy(vdst, dsrc)` – like `vd_copy` but always NUL terminates the
+ - `zvp_copy(vdst, dsrc)` – like `vp_copy` but always NUL terminates the
    destination even when the source overflows.
 
 ```c
 const char *src = "abc";
-zvd_copy(tmp, src);
+zvp_copy(tmp, src);
 ```
 
 #### `fixed.h`

--- a/doc/Implementation-Roadmap.md
+++ b/doc/Implementation-Roadmap.md
@@ -78,7 +78,7 @@ Only proceed once fixed operations are solid.
 
 | Prefix        | Description                                    |
 | ------------- | ---------------------------------------------- |
-| `vd_` / `dv_` | `VARCHAR` ↔ dynamic string (`malloc`-backed).  |
+| `dv_`         | dynamic string (`malloc`-backed) ↔ fixed `VARCHAR`. |
 | `vp_` / `pv_` | `VARCHAR` ↔ `char *`, possibly unknown origin. |
 | `vx_` / `xv_` | `VARCHAR` ↔ `VARCHAR *`.                       |
 

--- a/include/vsuite.h
+++ b/include/vsuite.h
@@ -7,6 +7,6 @@
 
 #include <vsuite/fixed.h>
 
-#include <vsuite/cstr.h>
+#include <vsuite/pstr.h>
 
 #endif /* VSUITE_H */

--- a/include/vsuite/pstr.h
+++ b/include/vsuite/pstr.h
@@ -1,5 +1,5 @@
-#ifndef VSUITE_CSTR_H
-#define VSUITE_CSTR_H
+#ifndef VSUITE_PSTR_H
+#define VSUITE_PSTR_H
 
 #include <stdlib.h>
 #include <string.h>
@@ -8,15 +8,15 @@
 #include <vsuite/varchar.h>
 
 /*
- * vd_copy() - Copy from a dynamic C string into a fixed VARCHAR.
+ * vp_copy() - Copy from a C string pointer into a fixed VARCHAR.
  * @vdst: Destination VARCHAR.
- * @dsrc: Source C string.
+ * @dsrc: Source C string pointer.
  *
  * The copy only succeeds when the source fits entirely within the destination
  * buffer.  Otherwise ``vdst.len`` is cleared to zero so callers can detect the
  * overflow.
  */
-#define vd_copy(vdst, dsrc)                                                   \
+#define vp_copy(vdst, dsrc)                                                   \
     do {                                                                      \
         size_t __n = strlen(dsrc);                                            \
         if (__n < V_SIZE(vdst)) {                                             \
@@ -28,22 +28,22 @@
     } while (0)
 
 /*
- * zvd_copy() - Copy a dynamic C string and always NUL terminate the result.
+ * zvp_copy() - Copy a C string pointer and always NUL terminate the result.
  */
-#define zvd_copy(vdst, dsrc)                                                  \
+#define zvp_copy(vdst, dsrc)                                                  \
     do {                                                                      \
-        vd_copy(vdst, dsrc);                                                  \
+        vp_copy(vdst, dsrc);                                                  \
         zv_zero_term(vdst);                                                   \
     } while (0)
 
 /*
- * dv_copy() - Copy a VARCHAR into a preallocated dynamic C string buffer.
+ * pv_copy() - Copy a VARCHAR into a preallocated C string buffer.
  *
  * ``dstr`` must have capacity ``dcap``. When the source fits the data is copied
  * and a terminator appended.  Otherwise the destination is cleared to an empty
  * string (if ``dcap`` is non-zero).
  */
-#define dv_copy(dstr, dcap, vsrc)                                             \
+#define pv_copy(dstr, dcap, vsrc)                                             \
     do {                                                                      \
         if ((vsrc).len < (dcap)) {                                            \
             memcpy(dstr, V_BUF(vsrc), (vsrc).len);                            \
@@ -74,4 +74,4 @@ static inline char *dv_dup_fcn(const char *src_buf, unsigned short src_len)
     return d;
 }
 
-#endif /* VSUITE_CSTR_H */
+#endif /* VSUITE_PSTR_H */

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,7 +16,7 @@ all: $(PROGRAMS)
 test-varchar.ex:    test-varchar.c    ${IV}/varchar.h
 test-zvarchar:   test-zvarchar.c   ${IV}/varchar.h  ${IV}/zvarchar.h
 test-fixed:      test-fixed.c      ${IV}/varchar.h  ${IV}/fixed.h
-test-cstr:       test-cstr.c       ${IV}/varchar.h  ${IV}/cstr.h
+test-cstr:       test-cstr.c       ${IV}/varchar.h  ${IV}/pstr.h
 
 test: all
 	@ for target in $(PROGRAMS) ; do \

--- a/tests/test-cstr.c
+++ b/tests/test-cstr.c
@@ -2,8 +2,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include "vsuite/varchar.h"
-#include "vsuite/zvarchar.h" /* for zvd_copy helpers */
-#include "vsuite/cstr.h"
+#include "vsuite/zvarchar.h" /* for zvp_copy helpers */
+#include "vsuite/pstr.h"
 
 static int failures = 0;
 static int verbose = 0;
@@ -20,164 +20,164 @@ static int verbose = 0;
 } while (0)
 
 /*
- * Verify vd_copy() copies from a NUL terminated C string into a VARCHAR
+ * Verify vp_copy() copies from a NUL terminated C string into a VARCHAR
  * when the source fits in the destination.  The length field should be
  * updated and the bytes copied verbatim.
  */
-static void test_vd_copy(void) {
+static void test_vp_copy(void) {
     VARCHAR(dst, 6);
     const char *src = "abc";
-    vd_copy(dst, src);
-    CHECK("vd_copy  len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
+    vp_copy(dst, src);
+    CHECK("vp_copy  len", dst.len == 3 && memcmp(dst.arr, "abc", 3) == 0);
 }
 
 /*
  * When the C string is too large for the destination the macro should
  * clear the destination length to zero so callers can detect the error.
  */
-static void test_vd_copy_overflow(void) {
+static void test_vp_copy_overflow(void) {
     VARCHAR(dst, 4);
     const char *src = "abcd";
-    vd_copy(dst, src);
-    CHECK("vd_copy  overflow", dst.len == 0); /* no data copied */
+    vp_copy(dst, src);
+    CHECK("vp_copy  overflow", dst.len == 0); /* no data copied */
 }
 
 /* Copying an empty string should yield an empty VARCHAR. */
-static void test_vd_copy_empty(void) {
+static void test_vp_copy_empty(void) {
     VARCHAR(dst, 4);
     const char *src = "";
-    vd_copy(dst, src);
-    CHECK("vd_copy  empty", dst.len == 0);
+    vp_copy(dst, src);
+    CHECK("vp_copy  empty", dst.len == 0);
 }
 
-/* zvd_copy behaves like vd_copy but always NUL terminates the target. */
-static void test_zvd_copy(void) {
+/* zvp_copy behaves like vp_copy but always NUL terminates the target. */
+static void test_zvp_copy(void) {
     VARCHAR(dst, 6);
     const char *src = "abc";
-    zvd_copy(dst, src);
-    CHECK("zvd_copy len", dst.len == 3 && strcmp(dst.arr, "abc") == 0);
+    zvp_copy(dst, src);
+    CHECK("zvp_copy len", dst.len == 3 && strcmp(dst.arr, "abc") == 0);
 }
 
-/* Overflow when using zvd_copy clears length and leaves a terminator. */
-static void test_zvd_copy_overflow(void) {
+/* Overflow when using zvp_copy clears length and leaves a terminator. */
+static void test_zvp_copy_overflow(void) {
     VARCHAR(dst, 4);
     const char *src = "abcd";
-    zvd_copy(dst, src);
-    CHECK("zvd_copy overflow", dst.len == 0 && dst.arr[0] == '\0');
+    zvp_copy(dst, src);
+    CHECK("zvp_copy overflow", dst.len == 0 && dst.arr[0] == '\0');
 }
 
-/* Empty string through zvd_copy should yield an empty, terminated VARCHAR. */
-static void test_zvd_copy_empty(void) {
+/* Empty string through zvp_copy should yield an empty, terminated VARCHAR. */
+static void test_zvp_copy_empty(void) {
     VARCHAR(dst, 2);
     const char *src = "";
-    zvd_copy(dst, src);
-    CHECK("zvd_copy empty", dst.len == 0 && dst.arr[0] == '\0');
+    zvp_copy(dst, src);
+    CHECK("zvp_copy empty", dst.len == 0 && dst.arr[0] == '\0');
 }
 
-/* Large buffer stress test for zvd_copy. */
-static void test_zvd_copy_large(void) {
+/* Large buffer stress test for zvp_copy. */
+static void test_zvp_copy_large(void) {
     enum { N = 8192 };
     char src[N + 1];
     memset(src, 'd', N);
     src[N] = '\0';
     VARCHAR(dst, N + 1);
-    zvd_copy(dst, src);
+    zvp_copy(dst, src);
     int ok = (dst.len == N && dst.arr[N] == '\0' && memcmp(dst.arr, src, N) == 0);
-    CHECK("zvd_copy large", ok);
+    CHECK("zvp_copy large", ok);
 }
 
 /*
- * Stress-test vd_copy with a very large source string. This ensures copying
+ * Stress-test vp_copy with a very large source string. This ensures copying
  * from a C string into a VARCHAR works correctly for buffers well beyond
  * typical small sizes.
  */
-static void test_vd_copy_large(void) {
+static void test_vp_copy_large(void) {
     enum { N = 8192 };
     char src[N + 1];
     memset(src, 'a', N);
     src[N] = '\0';
     VARCHAR(dst, N + 1);
-    vd_copy(dst, src);
+    vp_copy(dst, src);
     int ok = (dst.len == N && memcmp(dst.arr, src, N) == 0);
-    CHECK("vd_copy  large", ok);
+    CHECK("vp_copy  large", ok);
 }
 
 /*
- * dv_copy() transfers a VARCHAR into a preallocated C buffer.  When the
+ * pv_copy() transfers a VARCHAR into a preallocated C buffer.  When the
  * buffer is large enough the result should be a NUL terminated duplicate of
  * the source.
  */
-static void test_dv_copy(void) {
+static void test_pv_copy(void) {
     char dst[6];
     VARCHAR(src, 6);
     strcpy(src.arr, "abc");
     src.len = 3;
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy  len", strcmp(dst, "abc") == 0);
+    pv_copy(dst, sizeof(dst), src);
+    CHECK("pv_copy  len", strcmp(dst, "abc") == 0);
 }
 
 /*
- * If the destination buffer is too small dv_copy() should write an empty
+ * If the destination buffer is too small pv_copy() should write an empty
  * string so that callers know truncation occurred.
  */
-static void test_dv_copy_overflow(void) {
+static void test_pv_copy_overflow(void) {
     char dst[4];
     VARCHAR(src, 6);
     strcpy(src.arr, "abcd");
     src.len = 4;
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy  overflow", dst[0] == '\0'); /* buffer cleared */
+    pv_copy(dst, sizeof(dst), src);
+    CHECK("pv_copy  overflow", dst[0] == '\0'); /* buffer cleared */
 }
 
 /* Copying from an empty VARCHAR results in an empty destination C string. */
-static void test_dv_copy_empty(void) {
+static void test_pv_copy_empty(void) {
     char dst[4];
     VARCHAR(src, 4);
     src.len = 0;
     src.arr[0] = '\0';
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy  empty", dst[0] == '\0');
+    pv_copy(dst, sizeof(dst), src);
+    CHECK("pv_copy  empty", dst[0] == '\0');
 }
 
 /*
- * When the destination capacity is reported as zero dv_copy() must not
+ * When the destination capacity is reported as zero pv_copy() must not
  * touch the buffer at all.
  */
-static void test_dv_copy_zero_cap(void) {
+static void test_pv_copy_zero_cap(void) {
     char dst[1];
     VARCHAR(src, 2);
     strcpy(src.arr, "a");
     src.len = 1;
     dst[0] = 'x';
-    dv_copy(dst, 0, src);
-    CHECK("dv_copy  zero cap", dst[0] == 'x');
+    pv_copy(dst, 0, src);
+    CHECK("pv_copy  zero cap", dst[0] == 'x');
 }
 
-/* dv_copy with a size-one buffer should yield an empty string. */
-static void test_dv_copy_dest_size_one(void) {
+/* pv_copy with a size-one buffer should yield an empty string. */
+static void test_pv_copy_dest_size_one(void) {
     char dst[1];
     VARCHAR(src, 2);
     strcpy(src.arr, "a");
     src.len = 1;
-    dv_copy(dst, sizeof(dst), src);
-    CHECK("dv_copy  tiny", dst[0] == '\0');
+    pv_copy(dst, sizeof(dst), src);
+    CHECK("pv_copy  tiny", dst[0] == '\0');
 }
 
 /*
- * Stress-test dv_copy with a very large VARCHAR source. This validates
+ * Stress-test pv_copy with a very large VARCHAR source. This validates
  * copying into a fixed C buffer and that the destination is properly
  * NUL-terminated.
  */
-static void test_dv_copy_large(void) {
+static void test_pv_copy_large(void) {
     enum { N = 8192 };
     char dst[N + 1];
     VARCHAR(src, N + 1);
     memset(src.arr, 'b', N);
     src.arr[N] = '\0';
     src.len = N;
-    dv_copy(dst, sizeof(dst), src);
+    pv_copy(dst, sizeof(dst), src);
     int ok = (memcmp(dst, src.arr, N) == 0 && dst[N] == '\0');
-    CHECK("dv_copy  large", ok);
+    CHECK("pv_copy  large", ok);
 }
 
 /*
@@ -242,22 +242,22 @@ int main(int argc, char **argv) {
     for (int i=1;i<argc;i++)
         verbose |= (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose"));
 
-    test_vd_copy();
-    test_vd_copy_overflow();
-    test_vd_copy_empty();
-    test_vd_copy_large();
+    test_vp_copy();
+    test_vp_copy_overflow();
+    test_vp_copy_empty();
+    test_vp_copy_large();
 
-    test_zvd_copy();
-    test_zvd_copy_overflow();
-    test_zvd_copy_empty();
-    test_zvd_copy_large();
+    test_zvp_copy();
+    test_zvp_copy_overflow();
+    test_zvp_copy_empty();
+    test_zvp_copy_large();
 
-    test_dv_copy();
-    test_dv_copy_overflow();
-    test_dv_copy_empty();
-    test_dv_copy_dest_size_one();
-    test_dv_copy_zero_cap();
-    test_dv_copy_large();
+    test_pv_copy();
+    test_pv_copy_overflow();
+    test_pv_copy_empty();
+    test_pv_copy_dest_size_one();
+    test_pv_copy_zero_cap();
+    test_pv_copy_large();
 
     test_dv_dup_basic();
     test_dv_dup_empty();


### PR DESCRIPTION
## Summary
- rename `cstr.h` -> `pstr.h`
- rename macros for C string pointer support
- document new `pstr` header and prefix usage
- update test suite for new names

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_687ec42570e0832697bd6513eae2f854