### PR TITLE
Add --only option to better-varchar

### DIFF
--- a/tests/test_better_varchar.py
+++ b/tests/test_better_varchar.py
@@ -28,5 +28,18 @@ class TestBetterVarchar(unittest.TestCase):
         out = better_varchar.transform(src)
         self.assertIn('vp_copy(foo, "hi");', out)
 
+    def test_only_filter(self):
+        src = (
+            "strcpy(foo.arr, bar.arr);\nfoo.arr[bar.len] = '\0';\n"
+            "foo.arr[foo.len] = '\0';"
+        )
+        out = better_varchar.transform(src, only=['setlenz'])
+        self.assertIn('VARCHAR_SETLENZ(foo);', out)
+        self.assertNotIn('v_copy(foo, bar);', out)
+
+    def test_parse_only(self):
+        args = better_varchar.parse_args(['--only:vp_copy', 'in.pc', 'out.pc'])
+        self.assertEqual(args.only, ['vp_copy'])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- document new `--only:X` flag in the `better-varchar.py` help text
- support parsing `--only:X` options
- apply only the selected transforms when `--only` is specified
- expose `only` argument in `transform()` and `main()`
- test the new functionality

## Testing
- `python3 -m unittest -v tests/test_better_varchar.py`

------
https://chatgpt.com/codex/tasks/task_b_6880e6e4071883269d1690b89da369ab