### PR TITLE
Update show flag usage

### DIFF
--- a/better-varchar.py
+++ b/better-varchar.py
@@ -24,7 +24,7 @@ The following conversions are currently supported:
     ``sprintf(FOO.arr, fmt, ...);`` becomes ``VARCHAR_sprintf(FOO, fmt, ...);``.
 
 Usage:
-    better-varchar.py [options] <input-pc-file> <output-pc-file>
+    better-varchar.py [options] <input-pc-file> [<output-pc-file>]
 
 Options:
     -h --help          Show this help message and exit.
@@ -34,8 +34,9 @@ Options:
                        ``B`` are percentages (``50%``) or decimals (``0.5``).
     --function NAME    Restrict transformations to functions with ``NAME``.
                        May be repeated.
-    --show            Display the text that would be transformed.  No output
-                       file is written and the input is left untouched.
+    --show            Display the text that would be transformed and exit.
+                       When this option is used the output file argument
+                       must be omitted.
     --only:X          Selectively apply the specified transform.  May repeat
                        and also limits what is shown when ``--show`` is used.
 """
@@ -72,12 +73,12 @@ def parse_args(argv=None):
 
     parser = argparse.ArgumentParser(
         prog="better-varchar.py",
-        usage="better-varchar.py [options] <input-pc-file> <output-pc-file>",
+        usage="better-varchar.py [options] <input-pc-file> [<output-pc-file>]",
         description="Replace basic VARCHAR actions with macros.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("input_pc_file")
-    parser.add_argument("output_pc_file")
+    parser.add_argument("output_pc_file", nargs="?")
     parser.add_argument("--version", action="version", version=VERSION)
     parser.add_argument(
         "--lines",
@@ -101,7 +102,10 @@ def parse_args(argv=None):
     parser.add_argument(
         "--show",
         action="store_true",
-        help="Display text that would be transformed without modifying the input",
+        help=(
+            "Display text that would be transformed without modifying the input"
+            " and do not require an output file"
+        ),
     )
     parser.add_argument(
         "--only",
@@ -113,6 +117,13 @@ def parse_args(argv=None):
     if args.only:
         only_opts.extend(args.only)
     args.only = only_opts
+
+    if args.show:
+        if args.output_pc_file is not None:
+            parser.error("output_pc_file must not be specified with --show")
+    elif args.output_pc_file is None:
+        parser.error("the following arguments are required: output_pc_file")
+
     return args
 
 

--- a/tests/test_better_varchar.py
+++ b/tests/test_better_varchar.py
@@ -43,9 +43,13 @@ class TestBetterVarchar(unittest.TestCase):
         self.assertEqual(args.only, ['vp_copy'])
 
     def test_parse_show(self):
-        args = better_varchar.parse_args(['--show', '--only:setlenz', 'in.pc', 'out.pc'])
+        args = better_varchar.parse_args(['--show', '--only:setlenz', 'in.pc'])
         self.assertTrue(args.show)
         self.assertEqual(args.only, ['setlenz'])
+
+    def test_parse_show_with_output_error(self):
+        with self.assertRaises(SystemExit):
+            better_varchar.parse_args(['--show', 'in.pc', 'out.pc'])
 
     def test_show_no_write(self):
         import tempfile
@@ -55,7 +59,7 @@ class TestBetterVarchar(unittest.TestCase):
             out_path = os.path.join(tmpdir, 'out.pc')
             with open(in_path, 'w') as fh:
                 fh.write("FOO.arr[FOO.len] = '\0';\n")
-            better_varchar.main(['--show', in_path, out_path])
+            better_varchar.main(['--show', in_path])
             self.assertFalse(os.path.exists(out_path))
         finally:
             if os.path.exists(in_path):


### PR DESCRIPTION
## Summary
- allow running `better-varchar.py --show` without specifying an output file
- error if an output file is passed with `--show`
- update documentation and command-line help
- adjust and extend tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6880f21ff1e883268ca88bf6a0d0bc0d