### PR TITLE
Add v_copy_0 transform

### DIFF
--- a/test-better-varchar.c
+++ b/test-better-varchar.c
@@ -1,0 +1,13 @@
+#include <string.h>
+#include "vsuite/varchar.h"
+
+int main(void) {
+    VARCHAR(src, 8);
+    VARCHAR(dst, 8);
+
+    strcpy((char*)dst.arr, (char*)src.arr);
+    dst.len = strlen(dst.arr);
+    dst.arr[dst.len] = '\0';
+
+    return dst.len;
+}


### PR DESCRIPTION
## Summary
- add v_copy_0 pattern in better-varchar.py
- update transform ordering and documentation
- provide simple C sample `test-better-varchar.c`

## Testing
- `python3 -m unittest -v tests/test_better_varchar.py`
- `make test` *(fails: undefined reference to `VARCHAR_v_valid`)*
- `gcc -Wall -Wextra -std=gnu99 -Iinclude -c test-better-varchar.c`
- `gcc -Wall -Wextra -std=gnu99 -Iinclude test-better-varchar.o -o test-better-varchar`
- `./test-better-varchar`

------
https://chatgpt.com/codex/tasks/task_b_68837d5a165c8326a83c8bcf81c846df